### PR TITLE
fix: move setTimeout out of NgZone #53

### DIFF
--- a/lib/src/countdown.component.ts
+++ b/lib/src/countdown.component.ts
@@ -14,6 +14,7 @@ import {
   LOCALE_ID,
   ChangeDetectorRef,
   TemplateRef,
+  NgZone,
 } from '@angular/core';
 
 import { CountdownConfig, CountdownStatus, CountdownEvent, CountdownEventAction, CountdownItem } from './interfaces';
@@ -49,6 +50,7 @@ export class CountdownComponent implements OnInit, OnChanges, OnDestroy {
     private timer: CountdownTimer,
     private defCog: CountdownGlobalConfig,
     private cdr: ChangeDetectorRef,
+    private ngZone: NgZone,
   ) {}
 
   get left() {
@@ -165,13 +167,17 @@ export class CountdownComponent implements OnInit, OnChanges, OnDestroy {
     this.cdr.detectChanges();
 
     if (config.notify === 0 || _notify[value]) {
-      this.callEvent('notify');
+      this.ngZone.run(() => {
+        this.callEvent('notify');
+      });
     }
 
     if (value < 1) {
-      this.status = CountdownStatus.done;
-      this.callEvent('done');
-      this.destroy();
+      this.ngZone.run(() => {
+        this.status = CountdownStatus.done;
+        this.callEvent('done');
+        this.destroy();
+      });
     }
   }
 

--- a/lib/src/countdown.timer.ts
+++ b/lib/src/countdown.timer.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 
 @Injectable()
 export class CountdownTimer {
@@ -7,12 +7,16 @@ export class CountdownTimer {
   private nextTime: number;
   private ing = false;
 
+  constructor(private ngZone: NgZone) {}
+
   start() {
     if (this.ing === true) return;
 
     this.ing = true;
     this.nextTime = +new Date();
-    this.process();
+    this.ngZone.runOutsideAngular(() => {
+      this.process();
+    });
   }
 
   private process() {

--- a/src/app/components/demo.component.ts
+++ b/src/app/components/demo.component.ts
@@ -1,5 +1,5 @@
 // tslint:disable: member-ordering
-import { Component, ViewEncapsulation, ViewChild, Inject, LOCALE_ID } from '@angular/core';
+import { Component, ViewEncapsulation, ViewChild, Inject, LOCALE_ID, DoCheck } from '@angular/core';
 import { formatDate } from '@angular/common';
 import { CountdownComponent, CountdownConfig, CountdownEvent } from 'ngx-countdown';
 import { format } from 'date-fns';
@@ -12,8 +12,9 @@ const MINIUES = 1000 * 60;
   styleUrls: ['./demo.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class DemoComponent {
+export class DemoComponent implements DoCheck {
   @ViewChild('countdown', { static: false }) private counter: CountdownComponent;
+  doCheckCounter = 0;
   stopConfig: CountdownConfig = { stopTime: new Date().getTime() + 1000 * 30 };
   notify: string;
   config: CountdownConfig = { leftTime: 10, notify: [2, 5] };
@@ -67,5 +68,8 @@ export class DemoComponent {
       this.notify += ` - ${e.left} ms`;
     }
     console.log(e);
+  }
+  ngDoCheck() {
+    console.log(this.doCheckCounter++);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/cipchk/ngx-weui/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #53 

## What is the new behavior?
By default setTimeout is running inside Angular's zone, so after
every callback Angular will run change detection. By moving it
out of the zone it will have no effect on it. Calling detectChanges
in countdown.component.ts will update that component, but not
the others. All the other events called from `reflow` are put back
to the zone, so angular will run change detection.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
All tests are passing, but I need help with the new tests, because I could not figure out how to test the change detection calls. 